### PR TITLE
default strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All major changes to the project will be noted here
 
+## 2.2.0
+### Added
+- Strict mode
+### Changed
+- Default behavior will now follow `strict` mode, treating the `config` as source of truth
+- Strict mode will ignore any version/force overrides for `require` calls
+
 ## 2.1.2
 ### Added
 - Having default for config options

--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ Intelligent multi-version dependency management for npm packages.
 - #### Initialize 
 
 ```js
-const ry = require('requirey')(config);
+const ry = require('requirey')(config, options);
 ```
-`config` - object of module names mapped to arrays of supported versions
+`config` - object of module names mapped to arrays of supported versions   
+`options` - extra options to override default behaviors like `strict`
+
+**Default behavior is strict mode enabled which will always use config to determine which versions can be installed and required**
+
+**Strict mode will ignore version overrides for require calls**
 
 eg: 
 ```js

--- a/integration/integration.js
+++ b/integration/integration.js
@@ -7,11 +7,9 @@ const config = {
 
 describe('requirey - integration', () => {
   let ry;
-  before(() => {
-    ry = requirey(config);
-  });
 
   it('should install all and be requireable', (done) => {
+    ry = requirey(config, { strict: false });
     ry.installAll();
     let requirer = new ry.Requirer();
     let a = requirer.require('lodash@1.3.1');
@@ -26,7 +24,8 @@ describe('requirey - integration', () => {
     done();
   });
 
-  it('should find correct version intelligently', () => {
+  it('should find correct version intelligently in strict mode', () => {
+    ry = requirey(config);
     let requirer_1 = new ry.Requirer({
       dependencies: {
         lodash: '^3.0.0'
@@ -46,7 +45,8 @@ describe('requirey - integration', () => {
     expect(b.VERSION).to.equal('2.4.2');
   });
 
-  it('should be able to require subpaths', () => {
+  it('should be able to require subpaths in strict mode', () => {
+    ry = requirey(config);
     let requirer_1 = new ry.Requirer({
       dependencies: {
         lodash: '^3.0.0'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requirey",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "extending require to work with multiple versions of modules",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -15,7 +15,140 @@ jest.mock('lodash@2.2.0', () => 'lodash@2.2.0', { virtual: true });
 jest.mock('lodash@3.1.6', () => 'lodash@3.1.6', { virtual: true });
 jest.mock('lodash@3.1.6/package.json', () => 'lodash@3.1.6/package.json', { virtual: true });
 
-describe('requirey', () => {
+describe('requirey - strict mode', () => {
+  describe('installAll', () => {
+    it('should call install correctly', () => {
+      let config = {
+        lodash: ['1.0.0', '2.0.0']
+      };
+      let underTest = multi(config);
+      underTest.installAll();
+      expect(niv.install).toHaveBeenCalledTimes(2);
+      expect(niv.install).toHaveBeenCalledWith('lodash@1.0.0');
+      expect(niv.install).toHaveBeenCalledWith('lodash@2.0.0');
+      niv.install.mockClear();
+    });
+
+    it('should call install correctly with config of single version', () => {
+      let config = {
+        lodash: '1.0.0'
+      };
+      let underTest = multi(config);
+      underTest.installAll();
+      expect(niv.install).toHaveBeenCalledTimes(1);
+      expect(niv.install).toHaveBeenCalledWith('lodash@1.0.0');
+      niv.install.mockClear();
+    });
+  });
+
+  describe('install', () => {
+    let underTest;
+    afterEach(() => {
+      niv.install.mockClear();
+    })
+
+    it('should fail to install when no config provided', () => {
+      underTest = multi({}, { override: true });
+      expect(() => { underTest.install('lodash', '1.0.0'); }).toThrowError('lodash is not a supported module from the configuration');
+      expect(() => { underTest.install('lodash', '^1.1.0'); }).toThrowError('lodash is not a supported module from the configuration');
+      expect(() => { underTest.install('lodash', '~1.1.0'); }).toThrowError('lodash is not a supported module from the configuration');
+      expect(() => { underTest.install('lodash'); }).toThrowError('lodash is not a supported module from the configuration');
+    });
+
+    it('should fail to install when no supported version in config provided', () => {
+      underTest = multi({ lodash: ['3.10.1']}, { override: true });
+      expect(() => { underTest.install('lodash', '1.0.0'); }).toThrowError('lodash with version 1.0.0 is not supported in the configuration');
+      expect(() => { underTest.install('lodash', '^1.1.0'); }).toThrowError('lodash with version 1.1.0 is not supported in the configuration');
+      expect(() => { underTest.install('lodash', '~1.1.0'); }).toThrowError('lodash with version 1.1.0 is not supported in the configuration');
+      expect(() => { underTest.install('lodash'); }).toThrowError('lodash with version latest is not supported in the configuration');
+    });
+
+    it('should install when correct and version in config provided', () => {
+      underTest = multi({ lodash: ['3.10.1', '4.4.1']}, { override: true });
+      expect(() => { underTest.install('lodash', '3.10.1'); }).not.toThrowError();
+      expect(niv.install).toHaveBeenLastCalledWith('lodash@3.10.1');
+      expect(() => { underTest.install('lodash', '4.4.1'); }).not.toThrowError();
+      expect(niv.install).toHaveBeenLastCalledWith('lodash@4.4.1');
+      expect(() => { underTest.install('lodash', '^4.4.1'); }).not.toThrowError();
+      expect(niv.install).toHaveBeenLastCalledWith('lodash@4.4.1');
+    });
+  });
+
+  describe('requirer', () => {
+    let underTest;
+    afterEach(() => {
+      niv.require.mockClear();
+    });
+    it('should throw error when no config', () => {
+      underTest = multi({}, { override:  true });
+      const requirer = new underTest.Requirer();
+      expect(() => {requirer.require('lodash')}).toThrowError('no satisfying version found');
+    });
+
+    it('should throw error when no correct version', () => {
+      underTest = multi({ lodash: ['1.0.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
+      expect(() => {requirer.require('lodash')}).toThrowError('no satisfying version found');
+    });
+
+    it('should throw error when not in package.json', () => {
+      underTest = multi({ lodash: ['1.0.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { something: '^2.0.0' } });
+      expect(() => {requirer.require('lodash')}).toThrowError('no satisfying version found');
+    });
+
+    it('should return auto-detected version', () => {
+      underTest = multi({ lodash: ['2.0.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
+      let a = requirer.require('lodash', '3.0.0', { override:  true });
+      expect(a).toBe('lodash@2.0.0');
+    });
+
+    it('should get correct version from name', () => {
+      underTest = multi({ lodash: ['2.0.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
+      let a = requirer.require('lodash@~2.0.0');
+      expect(a).toBe('lodash@2.0.0');
+    });
+
+    it('should get max possible version when no package.json given', () => {
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '15.0.0'] }, { override:  true });
+      const requirer = new underTest.Requirer();
+      let a = requirer.require('lodash');
+      expect(a).toBe('lodash@15.0.0');
+    });
+
+    it('should get correct version based on package.json given with caret', () => {
+      underTest = multi({ lodash: ['2.0.0', '2.2.0', '3.0.0', '15.0.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
+      let a = requirer.require('lodash');
+      expect(a).toBe('lodash@2.2.0');
+    });
+
+    it('should get correct version based on package.json given with tilde', () => {
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '~3.1.0' } });
+      let a = requirer.require('lodash');
+      expect(a).toBe('lodash@3.1.6');
+    });
+
+    it('should require subpath', () => {
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '~3.1.0' } });
+      let a = requirer.require('lodash/package.json');
+      expect(a).toBe('lodash@3.1.6/package.json');
+    });
+
+    it('should require subpath with auto-detected version', () => {
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, { override:  true });
+      const requirer = new underTest.Requirer({ dependencies: { lodash: '~3.1.0' } });
+      let a = requirer.require('lodash@2.0.0/package.json');
+      expect(a).toBe('lodash@3.1.6/package.json');
+    });
+  });
+});
+
+describe('requirey - not strict mode', () => {
   describe('installAll', () => {
     it('should call install correctly', () => {
       let config = {
@@ -44,7 +177,7 @@ describe('requirey', () => {
   describe('install', () => {
     let underTest;
     beforeEach(() => {
-      underTest = multi();
+      underTest = multi({}, { strict: false });
     });
 
     afterEach(() => {
@@ -82,73 +215,73 @@ describe('requirey', () => {
       niv.require.mockClear();
     });
     it('should throw error when no config', () => {
-      underTest = multi({}, true);
+      underTest = multi({}, { override:  true, strict: false });
       const requirer = new underTest.Requirer();
       expect(() => {requirer.require('lodash')}).toThrowError('no satisfying version found');
     });
 
     it('should throw error when no correct version', () => {
-      underTest = multi({ lodash: ['1.0.0'] }, true);
+      underTest = multi({ lodash: ['1.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
       expect(() => {requirer.require('lodash')}).toThrowError('no satisfying version found');
     });
 
     it('should throw error when not in package.json', () => {
-      underTest = multi({ lodash: ['1.0.0'] }, true);
+      underTest = multi({ lodash: ['1.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { something: '^2.0.0' } });
       expect(() => {requirer.require('lodash')}).toThrowError('no satisfying version found');
     });
 
     it('should throw error when trying to get wrong version', () => {
-      underTest = multi({ lodash: ['2.0.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
       expect(() => {requirer.require('lodash', '3.0.0')}).toThrowError('no satisfying version found');
     });
 
     it('should not throw error when force to get version', () => {
-      underTest = multi({ lodash: ['2.0.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
       let a = requirer.require('lodash', '3.0.0', true);
       expect(a).toBe('lodash@3.0.0');
     });
 
     it('should get correct version from name', () => {
-      underTest = multi({ lodash: ['2.0.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
       let a = requirer.require('lodash@~2.0.0');
       expect(a).toBe('lodash@2.0.0');
     });
 
     it('should get max possible version when no package.json given', () => {
-      underTest = multi({ lodash: ['2.0.0', '3.0.0', '15.0.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '15.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer();
       let a = requirer.require('lodash');
       expect(a).toBe('lodash@15.0.0');
     });
 
     it('should get correct version based on package.json given with caret', () => {
-      underTest = multi({ lodash: ['2.0.0', '2.2.0', '3.0.0', '15.0.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0', '2.2.0', '3.0.0', '15.0.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '^2.0.0' } });
       let a = requirer.require('lodash');
       expect(a).toBe('lodash@2.2.0');
     });
 
     it('should get correct version based on package.json given with tilde', () => {
-      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '~3.1.0' } });
       let a = requirer.require('lodash');
       expect(a).toBe('lodash@3.1.6');
     });
 
     it('should require subpath', () => {
-      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '~3.1.0' } });
       let a = requirer.require('lodash/package.json');
       expect(a).toBe('lodash@3.1.6/package.json');
     });
 
     it('should require subpath with specified version', () => {
-      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, true);
+      underTest = multi({ lodash: ['2.0.0', '3.0.0', '3.1.6', '3.2.0'] }, { override:  true, strict: false });
       const requirer = new underTest.Requirer({ dependencies: { lodash: '~3.1.0' } });
       let a = requirer.require('lodash@2.0.0/package.json');
       expect(a).toBe('lodash@2.0.0/package.json');


### PR DESCRIPTION
this for #8 

The default strict mode will:
- only allow installs which are supported in the config
- always fetch `auto-detected` version using package.json and config 
- it will ignore version overrides like `require('module@<some_version>')` or ` require('module', '<version>')` and always return the version supported by package.json and config

The overrides can still be used in non-strict mode, which can be enabled by initializing with correct options: `const ry = require('requirey')(config, { strict: false })`
